### PR TITLE
Update requirements to avoid werkzug error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+Werkzeug>=1.0.0,<2.1.0
 ckanserviceprovider==0.0.11
 requests==2.25.1


### PR DESCRIPTION
Error in ClamAV application

<pre>

File "/usr/lib/python3.8/site-packages/gunicorn/util.py", line 350, in import_app
    __import__(module)
File "/srv/app/wsgi.py", line 3, in <module>
import ckanserviceprovider.web as web
File "/usr/lib/python3.8/site-packages/ckanserviceprovider/web.py", line 13, in <module>
    import flask_login as flogin
File "/usr/lib/python3.8/site-packages/flask_login/__init__.py", line 16, in <module>
    from .login_manager import LoginManager
File "/usr/lib/python3.8/site-packages/flask_login/login_manager.py", line 24, in <module>
    from .utils import (login_url as make_login_url, _create_identifier,
File "/usr/lib/python3.8/site-packages/flask_login/utils.py", line 13, in <module>
   from werkzeug.security import safe_str_cmp

<b>ImportError: cannot import name 'safe_str_cmp' from 'werkzeug.security' 
      (/usr/lib/python3.8/site-packages/werkzeug/security.py)</b>

[2022-04-12 17:51:33 +0000] [11] [INFO] Worker exiting (pid: 11)
</pre>

Werkzeug released [v2.1.0](https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0) a few days ago, removing `werkzeug.security.safe_str_cmp`.

We need to ensure `werkzug` to be < 2.1.0
